### PR TITLE
add callback event type

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -2,249 +2,27 @@
 
 namespace Basebuilder\Scheduling;
 
-use Carbon\Carbon;
-use Closure;
 use Cron\CronExpression;
-use Symfony\Component\Process\Process;
-use Symfony\Component\Process\ProcessUtils;
-use Webmozart\Assert\Assert;
 
-class Event
+interface Event
 {
     /**
-     * The command to run.
-     * @var string
-     */
-    protected $command;
-
-    /**
-     * The working directory.
-     * @var string
-     */
-    protected $cwd;
-
-    /**
-     * The user the command should run as.
-     * @var string
-     */
-    protected $user;
-
-    /**
-     * The cron expression representing the event's frequency.
-     * @var string
-     */
-    protected $expression = '* * * * * *';
-
-    /**
-     * The timezone the date should be evaluated on.
-     * @var \DateTimeZone|string
-     */
-    protected $timezone;
-
-    /**
-     * Indicates if the command should not overlap itself.
-     * @var bool
-     */
-    protected $mutuallyExclusive = false;
-
-    /**
-     * Indicates if the command should run in background.
-     * @var bool
-     */
-    protected $runInBackground = true;
-
-    /**
-     * The array of filter callbacks. These must return true
-     * @var array
-     */
-    protected $filters = [];
-
-    /**
-     * The array of reject callbacks.
-     * @var array
-     */
-    protected $rejects = [];
-
-    /**
-     * The location that output should be sent to.
-     * @var string
-     */
-    protected $output = '/dev/null';
-
-    /**
-     * The location of error output
-     * @var string
-     */
-    protected $errorOutput = '/dev/null';
-
-    /**
-     * Indicates whether output should be appended or added (> vs >>)
-     * @var bool
-     */
-    protected $shouldAppendOutput = true;
-
-    /**
-     * The array of callbacks to be run before the event is started.
-     * @var array
-     */
-    protected $beforeCallbacks = [];
-
-    /**
-     * The array of callbacks to be run after the event is finished.
-     * @var array
-     */
-    protected $afterCallbacks = [];
-
-    /**
-     * The human readable description of the event.
-     * @var string
-     */
-    public $description;
-
-    public function __construct(/* string */ $command)
-    {
-        Assert::stringNotEmpty($command);
-
-        $this->command = $command;
-    }
-
-    /**
      * @return string
      */
-    public function getCommand()
-    {
-        return $this->command;
-    }
+    public function __toString();
 
     /**
-     * @return string
+     * @param string $description
+     * @return $this
      */
-    public function __toString()
-    {
-        return $this->getCommand();
-    }
-
-    /**
-     * Build the command string.
-     *
-     * @return string
-     */
-    public function compileCommand()
-    {
-        $redirect    = $this->shouldAppendOutput ? '>>' : '>';
-        $output      = ProcessUtils::escapeArgument($this->output);
-        $errorOutput = ProcessUtils::escapeArgument($this->errorOutput);
-
-        // e.g. 1>> /dev/null 2>> /dev/null
-        $outputRedirect = ' 1' . $redirect . ' ' . $output . ' 2' . $redirect . ' ' . $errorOutput;
-
-        $parts = [];
-
-        if ($this->cwd) {
-            $parts[] =  'cd ' . $this->cwd . ';';
-        }
-
-        if ($this->user) {
-            $parts[] = 'sudo -u ' . $this->user . ' --';
-        }
-
-        $wrapped = $this->mutuallyExclusive
-            ? '(touch ' . $this->getMutexPath() . '; ' . $this->command . '; rm ' . $this->getMutexPath() . ')' . $outputRedirect
-            : $this->command . $outputRedirect;
-
-        $parts[] = "sh -c '{$wrapped}'";
-
-        $command = implode(' ', $parts);
-
-        return $command;
-    }
+    public function describe($description);
 
     /**
      * Run the given event.
      *
-     * @return Process
+     * @return mixed
      */
-    public function run()
-    {
-        foreach ($this->beforeCallbacks as $callback) {
-            call_user_func($callback);
-        }
-
-        if (!$this->runInBackground) {
-            $process = $this->runCommandInForeground();
-        } else {
-            $process = $this->runCommandInBackground();
-        }
-
-        foreach ($this->afterCallbacks as $callback) {
-            call_user_func($callback);
-        }
-
-        return $process;
-    }
-
-    /**
-     * Run the command in the foreground.
-     *
-     * @return Process
-     */
-    protected function runCommandInForeground()
-    {
-        $process = new Process($this->compileCommand(), $this->cwd, null, null, null);
-        $process->run();
-
-        return $process;
-    }
-
-    /**
-     * Run the command in the background.
-     *
-     * @return Process
-     */
-    protected function runCommandInBackground()
-    {
-        $process = new Process($this->compileCommand(), $this->cwd, null, null, null);
-        $process->start();
-
-        return $process;
-    }
-
-    /**
-     * Get the mutex path for managing concurrency
-     *
-     * @return string
-     */
-    protected function getMutexPath()
-    {
-        return rtrim(sys_get_temp_dir(), '/') . '/scheduled-event-' . md5($this->cwd . $this->command);
-    }
-
-    /**
-     * Do not allow the event to overlap each other.
-     *
-     * @return $this
-     */
-    public function preventOverlapping()
-    {
-        $this->mutuallyExclusive = true;
-
-        // Skip the event if it's locked (processing)
-        $this->skip(function() {
-            return $this->isLocked();
-        });
-
-        return $this;
-    }
-
-    /**
-     * Tells you whether this event has been denied from mutual exclusiveness
-     *
-     * @return bool
-     */
-    protected function isLocked()
-    {
-        return file_exists($this->getMutexPath());
-    }
+    public function run();
 
     /**
      * Schedule the event to run between start and end time.
@@ -253,10 +31,7 @@ class Event
      * @param  string  $endTime
      * @return $this
      */
-    public function between($startTime, $endTime)
-    {
-        return $this->when($this->inTimeInterval($startTime, $endTime));
-    }
+    public function between($startTime, $endTime);
 
     /**
      * Schedule the event to not run between start and end time.
@@ -265,184 +40,21 @@ class Event
      * @param  string  $endTime
      * @return $this
      */
-    public function notBetween($startTime, $endTime)
-    {
-        return $this->skip($this->inTimeInterval($startTime, $endTime));
-    }
-
-    /**
-     * Schedule the event to run between start and end time.
-     *
-     * @param  string  $startTime
-     * @param  string  $endTime
-     * @return \Closure
-     */
-    private function inTimeInterval($startTime, $endTime)
-    {
-        return function () use ($startTime, $endTime) {
-            $now = Carbon::now()->getTimestamp();
-            return $now >= strtotime($startTime) && $now <= strtotime($endTime);
-        };
-    }
-
-    /**
-     * State that the command should run in the foreground
-     *
-     * @return $this
-     */
-    public function runInForeground()
-    {
-        $this->runInBackground = false;
-
-        return $this;
-    }
-
-    /**
-     * State that the command should run in the background.
-     *
-     * @return $this
-     */
-    public function runInBackground()
-    {
-        $this->runInBackground = true;
-
-        return $this;
-    }
+    public function notBetween($startTime, $endTime);
 
     /**
      * Set the timezone the date should be evaluated on.
      *
      * @return $this
      */
-    public function timezone(\DateTimeZone $timezone)
-    {
-        $this->timezone = $timezone;
-
-        return $this;
-    }
-
-    /**
-     * Set which user the command should run as.
-     *
-     * @param  string?  $user
-     * @return $this
-     */
-    public function asUser(/* string? */ $user)
-    {
-        Assert::nullOrString($user);
-
-        $this->user = $user;
-
-        return $this;
-    }
+    public function timezone(\DateTimeZone $timezone);
 
     /**
      * Determine if the given event should run based on the Cron expression.
      *
      * @return bool
      */
-    public function isDue()
-    {
-        return $this->expressionPasses() && $this->filtersPass();
-    }
-
-    /**
-     * Determine if the Cron expression passes.
-     *
-     * @return boolean
-     */
-    protected function expressionPasses()
-    {
-        $date = Carbon::now();
-
-        if ($this->timezone) {
-            $date->setTimezone($this->timezone);
-        }
-
-        return $this->getCronExpression()->isDue($date->toDateTimeString());
-    }
-
-    /**
-     * Determine if the filters pass for the event.
-     *
-     * @return boolean
-     */
-    protected function filtersPass()
-    {
-        foreach ($this->filters as $callback) {
-            if (!call_user_func($callback)) {
-                return false;
-            }
-        }
-
-        foreach ($this->rejects as $callback) {
-            if (call_user_func($callback)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    /**
-     * Change the current working directory.
-     *
-     * @param  string $directory
-     * @return $this
-     */
-    public function in(/* string */ $directory)
-    {
-        Assert::stringNotEmpty($directory);
-
-        $this->cwd = $directory;
-
-        return $this;
-    }
-
-    /**
-     * Whether we append or redirect output
-     *
-     * @param bool $switch
-     * @return $this
-     */
-    public function appendOutput(/* boolean */ $switch = true)
-    {
-        Assert::boolean($switch);
-
-        $this->shouldAppendOutput = $switch;
-
-        return $this;
-    }
-
-    /**
-     * Set the file or location where to send file descriptor 1 to
-     *
-     * @param string $output
-     * @return $this
-     */
-    public function outputTo(/* string */ $output)
-    {
-        Assert::stringNotEmpty($output);
-
-        $this->output = $output;
-
-        return $this;
-    }
-
-    /**
-     * Set the file or location where to send file descriptor 2 to
-     *
-     * @param string $output
-     * @return $this
-     */
-    public function errorOutputTo(/* string */ $output)
-    {
-        Assert::stringNotEmpty($output);
-
-        $this->errorOutput = $output;
-
-        return $this;
-    }
+    public function isDue();
 
     /**
      * The Cron expression representing the event's frequency.
@@ -450,22 +62,12 @@ class Event
      * @param  string  $expression
      * @return $this
      */
-    public function cron(/* string */ $expression)
-    {
-        Assert::stringNotEmpty($expression);
-
-        $this->expression = $expression;
-
-        return $this;
-    }
+    public function cron(/* string */ $expression);
 
     /**
      * @return CronExpression
      */
-    public function getCronExpression()
-    {
-        return CronExpression::factory($this->expression);
-    }
+    public function getCronExpression();
 
     /**
      * Change the minute when the job should run (0-59, *, *\/2 etc)
@@ -473,30 +75,21 @@ class Event
      * @param  string|int $minute
      * @return $this
      */
-    public function minute($minute)
-    {
-        return $this->spliceIntoPosition(1, $minute);
-    }
+    public function minute($minute);
 
     /**
      * Schedule the event to run every minute.
      *
      * @return $this
      */
-    public function everyMinute()
-    {
-        return $this->minute('*');
-    }
+    public function everyMinute();
 
     /**
      * Schedule this event to run every 5 minutes
      *
      * @return Event
      */
-    public function everyFiveMinutes()
-    {
-        return $this->everyNMinutes(5);
-    }
+    public function everyFiveMinutes();
 
     /**
      * Schedule the event to run every N minutes
@@ -504,12 +97,7 @@ class Event
      * @param  int $n
      * @return $this
      */
-    public function everyNMinutes(/* int */ $n)
-    {
-        Assert::integer($n);
-
-        return $this->minute("*/{$n}");
-    }
+    public function everyNMinutes(/* int */ $n);
 
     /**
      * Set the hour when the job should run (0-23, *, *\/2, etc)
@@ -517,34 +105,21 @@ class Event
      * @param  string|int $hour
      * @return Event
      */
-    public function hour($hour)
-    {
-        return $this->spliceIntoPosition(2, $hour);
-    }
+    public function hour($hour);
 
     /**
      * Schedule the event to run hourly.
      *
      * @return $this
      */
-    public function hourly()
-    {
-        return $this
-            ->spliceIntoPosition(1, 0)
-            ->spliceIntoPosition(2, '*');
-    }
+    public function hourly();
 
     /**
      * Schedule the event to run daily.
      *
      * @return $this
      */
-    public function daily()
-    {
-        return $this
-            ->spliceIntoPosition(1, 0)
-            ->spliceIntoPosition(2, 0);
-    }
+    public function daily();
 
     /**
      * Schedule the event to run daily at a given time (10:00, 19:30, etc).
@@ -552,15 +127,7 @@ class Event
      * @param  string  $time
      * @return $this
      */
-    public function dailyAt(/* string */ $time)
-    {
-        Assert::stringNotEmpty($time);
-
-        $segments = explode(':', $time);
-
-        return $this->spliceIntoPosition(2, (int) $segments[0])
-            ->spliceIntoPosition(1, count($segments) == 2 ? (int) $segments[1] : '0');
-    }
+    public function dailyAt(/* string */ $time);
 
     /**
      * Set the days of the week the command should run on.
@@ -568,104 +135,70 @@ class Event
      * @param  array|mixed  $days
      * @return $this
      */
-    public function days($days)
-    {
-        $days = is_array($days) ? $days : func_get_args();
-
-        return $this->spliceIntoPosition(5, implode(',', $days));
-    }
+    public function days($days);
 
     /**
      * Schedule the event to run only on weekdays.
      *
      * @return $this
      */
-    public function weekdays()
-    {
-        return $this->spliceIntoPosition(5, '1-5');
-    }
+    public function weekdays();
 
     /**
      * Schedule the event to run only on Mondays.
      *
      * @return $this
      */
-    public function mondays()
-    {
-        return $this->days(1);
-    }
+    public function mondays();
 
     /**
      * Schedule the event to run only on Tuesdays.
      *
      * @return $this
      */
-    public function tuesdays()
-    {
-        return $this->days(2);
-    }
+    public function tuesdays();
 
     /**
      * Schedule the event to run only on Wednesdays.
      *
      * @return $this
      */
-    public function wednesdays()
-    {
-        return $this->days(3);
-    }
+    public function wednesdays();
 
     /**
      * Schedule the event to run only on Thursdays.
      *
      * @return $this
      */
-    public function thursdays()
-    {
-        return $this->days(4);
-    }
+    public function thursdays();
 
     /**
      * Schedule the event to run only on Fridays.
      *
      * @return $this
      */
-    public function fridays()
-    {
-        return $this->days(5);
-    }
+    public function fridays();
 
     /**
      * Schedule the event to run only on Saturdays.
      *
      * @return $this
      */
-    public function saturdays()
-    {
-        return $this->days(6);
-    }
+    public function saturdays();
 
     /**
      * Schedule the event to run only on Sundays.
      *
      * @return $this
      */
-    public function sundays()
-    {
-        return $this->days(0);
-    }
+    public function sundays();
 
     /**
      * Schedule the event to run weekly.
      *
      * @return $this
      */
-    public function weekly()
-    {
-        return $this->spliceIntoPosition(1, 0)
-            ->spliceIntoPosition(2, 0)
-            ->spliceIntoPosition(5, 0);
-    }
+    public function weekly();
 
     /**
      * Schedule the event to run weekly on a given day and time.
@@ -674,23 +207,14 @@ class Event
      * @param  string  $time
      * @return $this
      */
-    public function weeklyOn($day, $time = '0:0')
-    {
-        $this->dailyAt($time);
-        return $this->spliceIntoPosition(5, $day);
-    }
+    public function weeklyOn($day, $time = '0:0');
 
     /**
      * Schedule the event to run monthly.
      *
      * @return $this
      */
-    public function monthly()
-    {
-        return $this->spliceIntoPosition(1, 0)
-            ->spliceIntoPosition(2, 0)
-            ->spliceIntoPosition(3, 1);
-    }
+    public function monthly();
 
     /**
      * Schedule the event to run monthly on a given day and time.
@@ -699,101 +223,51 @@ class Event
      * @param string  $time
      * @return $this
      */
-    public function monthlyOn($day = 1, $time = '0:0')
-    {
-        $this->dailyAt($time);
-        return $this->spliceIntoPosition(3, $day);
-    }
+    public function monthlyOn($day = 1, $time = '0:0');
 
     /**
      * Schedule the event to run quarterly.
      *
      * @return $this
      */
-    public function quarterly()
-    {
-        return $this->spliceIntoPosition(1, 0)
-            ->spliceIntoPosition(2, 0)
-            ->spliceIntoPosition(3, 1)
-            ->spliceIntoPosition(4, '*/3');
-    }
+    public function quarterly();
 
     /**
      * Schedule the event to run yearly.
      *
      * @return $this
      */
-    public function yearly()
-    {
-        return $this->spliceIntoPosition(1, 0)
-            ->spliceIntoPosition(2, 0)
-            ->spliceIntoPosition(3, 1)
-            ->spliceIntoPosition(4, 1);
-    }
-
-    /**
-     * Splice the given value into the given position of the expression.
-     *
-     * @param  int  $position
-     * @param  string  $value
-     * @return $this
-     */
-    protected function spliceIntoPosition($position, $value)
-    {
-        $segments = explode(' ', $this->expression);
-        $segments[$position - 1] = $value;
-        return $this->cron(implode(' ', $segments));
-    }
+    public function yearly();
 
     /**
      * Register a callback to further filter the schedule.
      *
-     * @param  \Closure  $callback
+     * @param  callable  $callback
      * @return $this
      */
-    public function when(Closure $callback)
-    {
-        $this->filters[] = $callback;
-
-        return $this;
-    }
+    public function when(callable $callback);
 
     /**
      * Register a callback to further filter the schedule.
      *
-     * @param  \Closure  $callback
+     * @param  callable  $callback
      * @return $this
      */
-    public function skip(Closure $callback)
-    {
-        $this->rejects[] = $callback;
-
-        return $this;
-    }
+    public function skip(callable $callback);
 
     /**
      * Register a callback to be called before the operation.
      *
-     * @param \Closure $callback
+     * @param callable $callback
      * @return $this
      */
-    public function before(Closure $callback)
-    {
-        $this->beforeCallbacks[] = $callback;
-
-        return $this;
-    }
+    public function before(callable $callback);
 
     /**
      * Register a callback to be called after the operation.
      *
-     * @param  \Closure  $callback
+     * @param  callable  $callback
      * @return $this
      */
-    public function after(Closure $callback)
-    {
-        $this->afterCallbacks[] = $callback;
-
-        return $this;
-    }
+    public function after(callable $callback);
 }

--- a/src/Event/BaseEvent.php
+++ b/src/Event/BaseEvent.php
@@ -1,0 +1,515 @@
+<?php
+
+namespace Basebuilder\Scheduling\Event;
+
+use Basebuilder\Scheduling\Event;
+use Carbon\Carbon;
+use Cron\CronExpression;
+use Webmozart\Assert\Assert;
+
+abstract class BaseEvent implements Event
+{
+    /**
+     * The cron expression representing the event's frequency.
+     * @var string
+     */
+    protected $expression = '* * * * * *';
+
+    /**
+     * The timezone the date should be evaluated on.
+     * @var \DateTimeZone|string
+     */
+    protected $timezone;
+
+    /**
+     * The array of filter callbacks. These must return true
+     * @var callable[]
+     */
+    protected $filters = [];
+
+    /**
+     * The array of callbacks to be run before the event is started.
+     * @var callable[]
+     */
+    protected $beforeCallbacks = [];
+
+    /**
+     * The array of callbacks to be run after the event is finished.
+     * @var callable[]
+     */
+    protected $afterCallbacks = [];
+
+    /**
+     * The array of reject callbacks.
+     * @var callable[]
+     */
+    protected $rejects = [];
+
+    /**
+     * @var string
+     */
+    protected $description;
+
+    /**
+     * @param string $description
+     * @return $this
+     */
+    public function describe($description)
+    {
+        $this->description = $description;
+        return $this;
+    }
+
+    /**
+     * Schedule the event to run between start and end time.
+     *
+     * @param  string  $startTime
+     * @param  string  $endTime
+     * @return $this
+     */
+    public function between($startTime, $endTime)
+    {
+        return $this->when($this->inTimeInterval($startTime, $endTime));
+    }
+
+    /**
+     * Schedule the event to not run between start and end time.
+     *
+     * @param  string  $startTime
+     * @param  string  $endTime
+     * @return $this
+     */
+    public function notBetween($startTime, $endTime)
+    {
+        return $this->skip($this->inTimeInterval($startTime, $endTime));
+    }
+
+    /**
+     * Schedule the event to run between start and end time.
+     *
+     * @param  string  $startTime
+     * @param  string  $endTime
+     * @return \Closure
+     */
+    private function inTimeInterval($startTime, $endTime)
+    {
+        return function () use ($startTime, $endTime) {
+            $now = Carbon::now()->getTimestamp();
+            return $now >= strtotime($startTime) && $now <= strtotime($endTime);
+        };
+    }
+
+    /**
+     * Set the timezone the date should be evaluated on.
+     *
+     * @return $this
+     */
+    public function timezone(\DateTimeZone $timezone)
+    {
+        $this->timezone = $timezone;
+
+        return $this;
+    }
+
+    /**
+     * Determine if the given event should run based on the Cron expression.
+     *
+     * @return bool
+     */
+    public function isDue()
+    {
+        return $this->expressionPasses() && $this->filtersPass();
+    }
+
+    /**
+     * Determine if the Cron expression passes.
+     *
+     * @return boolean
+     */
+    protected function expressionPasses()
+    {
+        $date = Carbon::now();
+
+        if ($this->timezone) {
+            $date->setTimezone($this->timezone);
+        }
+
+        return $this->getCronExpression()->isDue($date->toDateTimeString());
+    }
+
+    /**
+     * Determine if the filters pass for the event.
+     *
+     * @return boolean
+     */
+    protected function filtersPass()
+    {
+        foreach ($this->filters as $callback) {
+            if (!call_user_func($callback)) {
+                return false;
+            }
+        }
+
+        foreach ($this->rejects as $callback) {
+            if (call_user_func($callback)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * The Cron expression representing the event's frequency.
+     *
+     * @param  string  $expression
+     * @return $this
+     */
+    public function cron(/* string */ $expression)
+    {
+        Assert::stringNotEmpty($expression);
+
+        $this->expression = $expression;
+
+        return $this;
+    }
+
+    /**
+     * @return CronExpression
+     */
+    public function getCronExpression()
+    {
+        return CronExpression::factory($this->expression);
+    }
+
+    /**
+     * Change the minute when the job should run (0-59, *, *\/2 etc)
+     *
+     * @param  string|int $minute
+     * @return $this
+     */
+    public function minute($minute)
+    {
+        return $this->spliceIntoPosition(1, $minute);
+    }
+
+    /**
+     * Schedule the event to run every minute.
+     *
+     * @return $this
+     */
+    public function everyMinute()
+    {
+        return $this->minute('*');
+    }
+
+    /**
+     * Schedule this event to run every 5 minutes
+     *
+     * @return $this
+     */
+    public function everyFiveMinutes()
+    {
+        return $this->everyNMinutes(5);
+    }
+
+    /**
+     * Schedule the event to run every N minutes
+     *
+     * @param  int $n
+     * @return $this
+     */
+    public function everyNMinutes(/* int */ $n)
+    {
+        Assert::integer($n);
+
+        return $this->minute("*/{$n}");
+    }
+
+    /**
+     * Set the hour when the job should run (0-23, *, *\/2, etc)
+     *
+     * @param  string|int $hour
+     * @return $this
+     */
+    public function hour($hour)
+    {
+        return $this->spliceIntoPosition(2, $hour);
+    }
+
+    /**
+     * Schedule the event to run hourly.
+     *
+     * @return $this
+     */
+    public function hourly()
+    {
+        return $this
+            ->spliceIntoPosition(1, 0)
+            ->spliceIntoPosition(2, '*');
+    }
+
+    /**
+     * Schedule the event to run daily.
+     *
+     * @return $this
+     */
+    public function daily()
+    {
+        return $this
+            ->spliceIntoPosition(1, 0)
+            ->spliceIntoPosition(2, 0);
+    }
+
+    /**
+     * Schedule the event to run daily at a given time (10:00, 19:30, etc).
+     *
+     * @param  string  $time
+     * @return $this
+     */
+    public function dailyAt(/* string */ $time)
+    {
+        Assert::stringNotEmpty($time);
+
+        $segments = explode(':', $time);
+
+        return $this->spliceIntoPosition(2, (int) $segments[0])
+            ->spliceIntoPosition(1, count($segments) == 2 ? (int) $segments[1] : '0');
+    }
+
+    /**
+     * Set the days of the week the command should run on.
+     *
+     * @param  array|mixed  $days
+     * @return $this
+     */
+    public function days($days)
+    {
+        $days = is_array($days) ? $days : func_get_args();
+
+        return $this->spliceIntoPosition(5, implode(',', $days));
+    }
+
+    /**
+     * Schedule the event to run only on weekdays.
+     *
+     * @return $this
+     */
+    public function weekdays()
+    {
+        return $this->spliceIntoPosition(5, '1-5');
+    }
+
+    /**
+     * Schedule the event to run only on Mondays.
+     *
+     * @return $this
+     */
+    public function mondays()
+    {
+        return $this->days(1);
+    }
+
+    /**
+     * Schedule the event to run only on Tuesdays.
+     *
+     * @return $this
+     */
+    public function tuesdays()
+    {
+        return $this->days(2);
+    }
+
+    /**
+     * Schedule the event to run only on Wednesdays.
+     *
+     * @return $this
+     */
+    public function wednesdays()
+    {
+        return $this->days(3);
+    }
+
+    /**
+     * Schedule the event to run only on Thursdays.
+     *
+     * @return $this
+     */
+    public function thursdays()
+    {
+        return $this->days(4);
+    }
+
+    /**
+     * Schedule the event to run only on Fridays.
+     *
+     * @return $this
+     */
+    public function fridays()
+    {
+        return $this->days(5);
+    }
+
+    /**
+     * Schedule the event to run only on Saturdays.
+     *
+     * @return $this
+     */
+    public function saturdays()
+    {
+        return $this->days(6);
+    }
+
+    /**
+     * Schedule the event to run only on Sundays.
+     *
+     * @return $this
+     */
+    public function sundays()
+    {
+        return $this->days(0);
+    }
+
+    /**
+     * Schedule the event to run weekly.
+     *
+     * @return $this
+     */
+    public function weekly()
+    {
+        return $this->spliceIntoPosition(1, 0)
+            ->spliceIntoPosition(2, 0)
+            ->spliceIntoPosition(5, 0);
+    }
+
+    /**
+     * Schedule the event to run weekly on a given day and time.
+     *
+     * @param  int  $day
+     * @param  string  $time
+     * @return $this
+     */
+    public function weeklyOn($day, $time = '0:0')
+    {
+        $this->dailyAt($time);
+        return $this->spliceIntoPosition(5, $day);
+    }
+
+    /**
+     * Schedule the event to run monthly.
+     *
+     * @return $this
+     */
+    public function monthly()
+    {
+        return $this->spliceIntoPosition(1, 0)
+            ->spliceIntoPosition(2, 0)
+            ->spliceIntoPosition(3, 1);
+    }
+
+    /**
+     * Schedule the event to run monthly on a given day and time.
+     *
+     * @param int  $day
+     * @param string  $time
+     * @return $this
+     */
+    public function monthlyOn($day = 1, $time = '0:0')
+    {
+        $this->dailyAt($time);
+        return $this->spliceIntoPosition(3, $day);
+    }
+
+    /**
+     * Schedule the event to run quarterly.
+     *
+     * @return $this
+     */
+    public function quarterly()
+    {
+        return $this->spliceIntoPosition(1, 0)
+            ->spliceIntoPosition(2, 0)
+            ->spliceIntoPosition(3, 1)
+            ->spliceIntoPosition(4, '*/3');
+    }
+
+    /**
+     * Schedule the event to run yearly.
+     *
+     * @return $this
+     */
+    public function yearly()
+    {
+        return $this->spliceIntoPosition(1, 0)
+            ->spliceIntoPosition(2, 0)
+            ->spliceIntoPosition(3, 1)
+            ->spliceIntoPosition(4, 1);
+    }
+
+    /**
+     * Splice the given value into the given position of the expression.
+     *
+     * @param  int  $position
+     * @param  string  $value
+     * @return $this
+     */
+    protected function spliceIntoPosition($position, $value)
+    {
+        $segments = explode(' ', $this->expression);
+        $segments[$position - 1] = $value;
+        return $this->cron(implode(' ', $segments));
+    }
+
+
+    /**
+     * Register a callback to further filter the schedule.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function when(callable $callback)
+    {
+        $this->filters[] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Register a callback to further filter the schedule.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function skip(callable $callback)
+    {
+        $this->rejects[] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Register a callback to be called before the operation.
+     *
+     * @param callable $callback
+     * @return $this
+     */
+    public function before(callable $callback)
+    {
+        $this->beforeCallbacks[] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Register a callback to be called after the operation.
+     *
+     * @param  callable  $callback
+     * @return $this
+     */
+    public function after(callable $callback)
+    {
+        $this->afterCallbacks[] = $callback;
+
+        return $this;
+    }
+}

--- a/src/Event/Callback.php
+++ b/src/Event/Callback.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Basebuilder\Scheduling\Event;
+
+class Callback extends BaseEvent
+{
+    /**
+     * @var callable
+     */
+    protected $callback;
+
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return !empty($this->description)
+            ? $this->description
+            : 'callback';
+    }
+
+    /**
+     * Run the given event.
+     *
+     * @return mixed
+     */
+    public function run()
+    {
+        call_user_func($this->callback);
+    }
+}

--- a/src/Event/Process.php
+++ b/src/Event/Process.php
@@ -1,0 +1,302 @@
+<?php
+
+namespace Basebuilder\Scheduling\Event;
+
+use Symfony\Component\Process\Process as OsProcess;
+use Symfony\Component\Process\ProcessUtils;
+use Webmozart\Assert\Assert;
+
+class Process extends BaseEvent
+{
+    /**
+     * The command to run.
+     * @var string
+     */
+    protected $command;
+
+    /**
+     * The working directory.
+     * @var string
+     */
+    protected $cwd;
+
+    /**
+     * The user the command should run as.
+     * @var string
+     */
+    protected $user;
+
+    /**
+     * Indicates if the command should not overlap itself.
+     * @var bool
+     */
+    protected $mutuallyExclusive = false;
+
+    /**
+     * Indicates if the command should run in background.
+     * @var bool
+     */
+    protected $runInBackground = true;
+
+    /**
+     * The location that output should be sent to.
+     * @var string
+     */
+    protected $output = '/dev/null';
+
+    /**
+     * The location of error output
+     * @var string
+     */
+    protected $errorOutput = '/dev/null';
+
+    /**
+     * Indicates whether output should be appended or added (> vs >>)
+     * @var bool
+     */
+    protected $shouldAppendOutput = true;
+
+    public function __construct(/* string */ $command)
+    {
+        Assert::stringNotEmpty($command);
+
+        $this->command = $command;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCommand()
+    {
+        return $this->command;
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->getCommand();
+    }
+
+    /**
+     * Build the command string.
+     *
+     * @return string
+     */
+    public function compileCommand()
+    {
+        $redirect    = $this->shouldAppendOutput ? '>>' : '>';
+        $output      = ProcessUtils::escapeArgument($this->output);
+        $errorOutput = ProcessUtils::escapeArgument($this->errorOutput);
+
+        // e.g. 1>> /dev/null 2>> /dev/null
+        $outputRedirect = ' 1' . $redirect . ' ' . $output . ' 2' . $redirect . ' ' . $errorOutput;
+
+        $parts = [];
+
+        if ($this->cwd) {
+            $parts[] =  'cd ' . $this->cwd . ';';
+        }
+
+        if ($this->user) {
+            $parts[] = 'sudo -u ' . $this->user . ' --';
+        }
+
+        $wrapped = $this->mutuallyExclusive
+            ? '(touch ' . $this->getMutexPath() . '; ' . $this->command . '; rm ' . $this->getMutexPath() . ')' . $outputRedirect
+            : $this->command . $outputRedirect;
+
+        $parts[] = "sh -c '{$wrapped}'";
+
+        $command = implode(' ', $parts);
+
+        return $command;
+    }
+
+    /**
+     * Run the given event.
+     *
+     * @return OsProcess
+     */
+    public function run()
+    {
+        foreach ($this->beforeCallbacks as $callback) {
+            call_user_func($callback);
+        }
+
+        if (!$this->runInBackground) {
+            $process = $this->runCommandInForeground();
+        } else {
+            $process = $this->runCommandInBackground();
+        }
+
+        foreach ($this->afterCallbacks as $callback) {
+            call_user_func($callback);
+        }
+
+        return $process;
+    }
+
+    /**
+     * Run the command in the foreground.
+     *
+     * @return OsProcess
+     */
+    protected function runCommandInForeground()
+    {
+        $process = new OsProcess($this->compileCommand(), $this->cwd, null, null, null);
+        $process->run();
+
+        return $process;
+    }
+
+    /**
+     * Run the command in the background.
+     *
+     * @return OsProcess
+     */
+    protected function runCommandInBackground()
+    {
+        $process = new OsProcess($this->compileCommand(), $this->cwd, null, null, null);
+        $process->start();
+
+        return $process;
+    }
+
+    /**
+     * Get the mutex path for managing concurrency
+     *
+     * @return string
+     */
+    protected function getMutexPath()
+    {
+        return rtrim(sys_get_temp_dir(), '/') . '/scheduled-event-' . md5($this->cwd . $this->command);
+    }
+
+    /**
+     * Do not allow the event to overlap each other.
+     *
+     * @return $this
+     */
+    public function preventOverlapping()
+    {
+        $this->mutuallyExclusive = true;
+
+        // Skip the event if it's locked (processing)
+        $this->skip(function() {
+            return $this->isLocked();
+        });
+
+        return $this;
+    }
+
+    /**
+     * Tells you whether this event has been denied from mutual exclusiveness
+     *
+     * @return bool
+     */
+    protected function isLocked()
+    {
+        return file_exists($this->getMutexPath());
+    }
+
+    /**
+     * State that the command should run in the foreground
+     *
+     * @return $this
+     */
+    public function runInForeground()
+    {
+        $this->runInBackground = false;
+
+        return $this;
+    }
+
+    /**
+     * State that the command should run in the background.
+     *
+     * @return $this
+     */
+    public function runInBackground()
+    {
+        $this->runInBackground = true;
+
+        return $this;
+    }
+
+    /**
+     * Set which user the command should run as.
+     *
+     * @param  string?  $user
+     * @return $this
+     */
+    public function asUser(/* string? */ $user)
+    {
+        Assert::nullOrString($user);
+
+        $this->user = $user;
+
+        return $this;
+    }
+
+    /**
+     * Change the current working directory.
+     *
+     * @param  string $directory
+     * @return $this
+     */
+    public function in(/* string */ $directory)
+    {
+        Assert::stringNotEmpty($directory);
+
+        $this->cwd = $directory;
+
+        return $this;
+    }
+
+    /**
+     * Whether we append or redirect output
+     *
+     * @param bool $switch
+     * @return $this
+     */
+    public function appendOutput(/* boolean */ $switch = true)
+    {
+        Assert::boolean($switch);
+
+        $this->shouldAppendOutput = $switch;
+
+        return $this;
+    }
+
+    /**
+     * Set the file or location where to send file descriptor 1 to
+     *
+     * @param string $output
+     * @return $this
+     */
+    public function outputTo(/* string */ $output)
+    {
+        Assert::stringNotEmpty($output);
+
+        $this->output = $output;
+
+        return $this;
+    }
+
+    /**
+     * Set the file or location where to send file descriptor 2 to
+     *
+     * @param string $output
+     * @return $this
+     */
+    public function errorOutputTo(/* string */ $output)
+    {
+        Assert::stringNotEmpty($output);
+
+        $this->errorOutput = $output;
+
+        return $this;
+    }
+}

--- a/src/Schedule.php
+++ b/src/Schedule.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace Basebuilder\Scheduling;
+use Basebuilder\Scheduling\Event\Callback;
+use Basebuilder\Scheduling\Event\Process;
 use Webmozart\Assert\Assert;
 
 /**
@@ -52,16 +54,18 @@ class Schedule
     /**
      * Creates a new Event, adds it to the schedule stack and returns you the instance so you can configure it
      *
-     * @param  string $command
+     * @param  callable|string $event
      * @return Event
      */
-    public function run(/* string */ $command)
+    public function run($event)
     {
-        Assert::stringNotEmpty($command);
-        $event = new Event($command);
+        if(is_callable($event)) {
+            $event = new Callback($event);
+        } else {
+            $event = new Process($event);
+        }
 
         $this->add($event);
-
         return $event;
     }
 

--- a/tests/Event/BaseEventTest.php
+++ b/tests/Event/BaseEventTest.php
@@ -7,7 +7,7 @@ class BaseEventTest extends \PHPUnit_Framework_TestCase
     /**
      * @return BaseEvent|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected function getMock()
+    protected function getEvent()
     {
         return $this->getMockBuilder(BaseEvent::class)->getMockForAbstractClass();
     }
@@ -17,7 +17,7 @@ class BaseEventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_every_minute()
     {
-        $event = $this->getMock();
+        $event = $this->getEvent();
 
         $event->everyMinute();
 
@@ -29,7 +29,7 @@ class BaseEventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_n_minutes()
     {
-        $event = $this->getMock();
+        $event = $this->getEvent();
         $event->everyNMinutes(5);
 
         $this->assertSame("*/5 * * * * *", (string) $event->getCronExpression());
@@ -40,7 +40,7 @@ class BaseEventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_hourly()
     {
-        $event = $this->getMock();
+        $event = $this->getEvent();
         $event->hourly();
 
         $this->assertSame('0 * * * * *', (string) $event->getCronExpression());
@@ -51,7 +51,7 @@ class BaseEventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_on_every_hour()
     {
-        $event = $this->getMock();
+        $event = $this->getEvent();
         $event->hour(1);
 
         $this->assertSame('* 1 * * * *', (string) $event->getCronExpression());
@@ -62,7 +62,7 @@ class BaseEventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_daily()
     {
-        $event = $this->getMock();
+        $event = $this->getEvent();
         $event->daily();
 
         $this->assertSame('0 0 * * * *', (string) $event->getCronExpression());
@@ -73,7 +73,7 @@ class BaseEventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_daily_at_a_specific_time()
     {
-        $event = $this->getMock();
+        $event = $this->getEvent();
         $event->dailyAt('10:05');
         $this->assertSame('5 10 * * * *', (string) $event->getCronExpression());
 
@@ -86,7 +86,7 @@ class BaseEventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_on_specific_days()
     {
-        $event = $this->getMock();
+        $event = $this->getEvent();
 
         $event->days([1, 2 ,3 ]);
         $this->assertSame('* * * * 1,2,3 *', (string) $event->getCronExpression());
@@ -100,7 +100,7 @@ class BaseEventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_on_weekdays_only()
     {
-        $event = $this->getMock();
+        $event = $this->getEvent();
         $event->weekdays();
 
         $this->assertSame('* * * * 1-5 *', (string) $event->getCronExpression());
@@ -111,7 +111,7 @@ class BaseEventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_weekly()
     {
-        $event = $this->getMock();
+        $event = $this->getEvent();
         $event->weekly();
 
         $this->assertSame('0 0 * * 0 *', (string) $event->getCronExpression());
@@ -122,7 +122,7 @@ class BaseEventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_monthly()
     {
-        $event = $this->getMock();
+        $event = $this->getEvent();
         $event->monthly();
 
         $this->assertSame('0 0 1 * * *', (string) $event->getCronExpression());
@@ -133,7 +133,7 @@ class BaseEventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_quarterly()
     {
-        $event = $this->getMock();
+        $event = $this->getEvent();
         $event->quarterly();
 
         $this->assertSame('0 0 1 */3 * *', (string) $event->getCronExpression());
@@ -144,7 +144,7 @@ class BaseEventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_yearly()
     {
-        $event = $this->getMock();
+        $event = $this->getEvent();
         $event->yearly();
 
         $this->assertSame('0 0 1 1 * *', (string) $event->getCronExpression());
@@ -155,7 +155,7 @@ class BaseEventTest extends \PHPUnit_Framework_TestCase
      */
     function it_allows_for_filtering()
     {
-        $event = $this->getMock();
+        $event = $this->getEvent();
         $event->everyMinute();
 
         $this->assertTrue($event->isDue());
@@ -166,7 +166,7 @@ class BaseEventTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($event->isDue());
 
-        $event = $this->getMock();
+        $event = $this->getEvent();
         $event->everyMinute();
 
         $this->assertTrue($event->isDue());

--- a/tests/Event/BaseEventTest.php
+++ b/tests/Event/BaseEventTest.php
@@ -1,61 +1,15 @@
 <?php
 
-use Basebuilder\Scheduling\Event;
+use Basebuilder\Scheduling\Event\BaseEvent;
 
-class EventTest extends \PHPUnit_Framework_TestCase
+class BaseEventTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @test
+     * @return BaseEvent|\PHPUnit_Framework_MockObject_MockObject
      */
-    function it_can_compile_the_command()
+    protected function getMock()
     {
-        $event = new Event('php -i');
-
-        $this->assertSame("sh -c 'php -i 1>> '/dev/null' 2>> '/dev/null''", $event->compileCommand());
-    }
-
-    /**
-     * @test
-     */
-    function it_can_switch_user()
-    {
-        $event = new Event('php -i');
-        $event->asUser('foo');
-
-        $this->assertSame("sudo -u foo -- sh -c 'php -i 1>> '/dev/null' 2>> '/dev/null''", $event->compileCommand());
-    }
-
-    /**
-     * @test
-     */
-    function it_can_switch_directory()
-    {
-        $event = new Event('php -i');
-        $event->in('/foo/bar');
-
-        $this->assertSame("cd /foo/bar; sh -c 'php -i 1>> '/dev/null' 2>> '/dev/null''", $event->compileCommand());
-    }
-
-    /**
-     * @test
-     */
-    function it_can_append_output()
-    {
-        $event = new Event('php -i');
-        $event->appendOutput(true);
-
-        $this->assertSame("sh -c 'php -i 1>> '/dev/null' 2>> '/dev/null''", $event->compileCommand());
-    }
-
-    /**
-     * @test
-     */
-    function it_can_overwrite_output()
-    {
-        $event = new Event('php -i');
-        $event->appendOutput(false);
-
-        $this->assertSame("sh -c 'php -i 1> '/dev/null' 2> '/dev/null''", $event->compileCommand());
+        return $this->getMockBuilder(BaseEvent::class)->getMockForAbstractClass();
     }
 
     /**
@@ -63,7 +17,8 @@ class EventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_every_minute()
     {
-        $event = new Event('php -i');
+        $event = $this->getMock();
+
         $event->everyMinute();
 
         $this->assertSame('* * * * * *', (string) $event->getCronExpression());
@@ -74,7 +29,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_n_minutes()
     {
-        $event = new Event('php -i');
+        $event = $this->getMock();
         $event->everyNMinutes(5);
 
         $this->assertSame("*/5 * * * * *", (string) $event->getCronExpression());
@@ -85,7 +40,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_hourly()
     {
-        $event = new Event('php -i');
+        $event = $this->getMock();
         $event->hourly();
 
         $this->assertSame('0 * * * * *', (string) $event->getCronExpression());
@@ -96,7 +51,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_on_every_hour()
     {
-        $event = new Event('php -i');
+        $event = $this->getMock();
         $event->hour(1);
 
         $this->assertSame('* 1 * * * *', (string) $event->getCronExpression());
@@ -107,7 +62,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_daily()
     {
-        $event = new Event('php -i');
+        $event = $this->getMock();
         $event->daily();
 
         $this->assertSame('0 0 * * * *', (string) $event->getCronExpression());
@@ -118,7 +73,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_daily_at_a_specific_time()
     {
-        $event = new Event('php -i');
+        $event = $this->getMock();
         $event->dailyAt('10:05');
         $this->assertSame('5 10 * * * *', (string) $event->getCronExpression());
 
@@ -131,7 +86,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_on_specific_days()
     {
-        $event = new Event('php -i');
+        $event = $this->getMock();
 
         $event->days([1, 2 ,3 ]);
         $this->assertSame('* * * * 1,2,3 *', (string) $event->getCronExpression());
@@ -145,7 +100,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_on_weekdays_only()
     {
-        $event = new Event('php -i');
+        $event = $this->getMock();
         $event->weekdays();
 
         $this->assertSame('* * * * 1-5 *', (string) $event->getCronExpression());
@@ -156,7 +111,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_weekly()
     {
-        $event = new Event('php -i');
+        $event = $this->getMock();
         $event->weekly();
 
         $this->assertSame('0 0 * * 0 *', (string) $event->getCronExpression());
@@ -167,7 +122,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_monthly()
     {
-        $event = new Event('php -i');
+        $event = $this->getMock();
         $event->monthly();
 
         $this->assertSame('0 0 1 * * *', (string) $event->getCronExpression());
@@ -178,7 +133,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_quarterly()
     {
-        $event = new Event('php -i');
+        $event = $this->getMock();
         $event->quarterly();
 
         $this->assertSame('0 0 1 */3 * *', (string) $event->getCronExpression());
@@ -189,7 +144,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
      */
     function it_can_run_yearly()
     {
-        $event = new Event('php -i');
+        $event = $this->getMock();
         $event->yearly();
 
         $this->assertSame('0 0 1 1 * *', (string) $event->getCronExpression());
@@ -200,7 +155,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
      */
     function it_allows_for_filtering()
     {
-        $event = new Event('php -i');
+        $event = $this->getMock();
         $event->everyMinute();
 
         $this->assertTrue($event->isDue());
@@ -211,7 +166,7 @@ class EventTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($event->isDue());
 
-        $event = new Event('php -i');
+        $event = $this->getMock();
         $event->everyMinute();
 
         $this->assertTrue($event->isDue());
@@ -221,16 +176,5 @@ class EventTest extends \PHPUnit_Framework_TestCase
         });
 
         $this->assertFalse($event->isDue());
-    }
-
-    /**
-     * @group fix
-     */
-    function it_can_prevent_overlapping()
-    {
-        $event = new Event('php -i');
-        $event->preventOverlapping();
-
-        preg_match('/\(touch \w*; php -i; rm \w*\); 1>> /dev/null 2>> /dev/null/', $event->compileCommand());
     }
 }

--- a/tests/Event/ProcessTest.php
+++ b/tests/Event/ProcessTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use Basebuilder\Scheduling\Event\Process;
+
+class ProcessTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     */
+    function it_can_compile_the_command()
+    {
+        $event = new Process('php -i');
+
+        $this->assertSame("sh -c 'php -i 1>> '/dev/null' 2>> '/dev/null''", $event->compileCommand());
+    }
+
+    /**
+     * @test
+     */
+    function it_can_switch_user()
+    {
+        $event = new Process('php -i');
+        $event->asUser('foo');
+
+        $this->assertSame("sudo -u foo -- sh -c 'php -i 1>> '/dev/null' 2>> '/dev/null''", $event->compileCommand());
+    }
+
+    /**
+     * @test
+     */
+    function it_can_switch_directory()
+    {
+        $event = new Process('php -i');
+        $event->in('/foo/bar');
+
+        $this->assertSame("cd /foo/bar; sh -c 'php -i 1>> '/dev/null' 2>> '/dev/null''", $event->compileCommand());
+    }
+
+    /**
+     * @test
+     */
+    function it_can_append_output()
+    {
+        $event = new Process('php -i');
+        $event->appendOutput(true);
+
+        $this->assertSame("sh -c 'php -i 1>> '/dev/null' 2>> '/dev/null''", $event->compileCommand());
+    }
+
+    /**
+     * @test
+     */
+    function it_can_overwrite_output()
+    {
+        $event = new Process('php -i');
+        $event->appendOutput(false);
+
+        $this->assertSame("sh -c 'php -i 1> '/dev/null' 2> '/dev/null''", $event->compileCommand());
+    }
+
+    /**
+     * @group fix
+     */
+    function it_can_prevent_overlapping()
+    {
+        $event = new Process('php -i');
+        $event->preventOverlapping();
+
+        preg_match('/\(touch \w*; php -i; rm \w*\); 1>> /dev/null 2>> /dev/null/', $event->compileCommand());
+    }
+}

--- a/tests/ScheduleTest.php
+++ b/tests/ScheduleTest.php
@@ -11,7 +11,7 @@ class ScheduleTest extends \PHPUnit_Framework_TestCase
     function it_converts_commands_to_events()
     {
         $schedule = new Schedule();
-        $event = $schedule->run('whoami');
+        $event = $schedule->run(function () {});
 
         $this->assertInstanceOf(Event::class, $event);
     }
@@ -22,7 +22,7 @@ class ScheduleTest extends \PHPUnit_Framework_TestCase
     function it_gets_us_all_events_that_are_due_for_processing()
     {
         $schedule = new Schedule();
-        $event = $schedule->run('whoami')->everyMinute();
+        $event = $schedule->run(function () {})->everyMinute();
 
         $this->assertEquals([$event], $schedule->dueEvents());
     }


### PR DESCRIPTION
This allows for callbacks to be used as scheduling events.

With this PR it is possible to use any sort of \callable instead of a reference to a file.
